### PR TITLE
Set jobs default based on number of available CPUs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -318,6 +318,9 @@ used to create the virtual environment.
 
 `vlttng` passes its `--jobs` (`-j`) option as is to `make`.
 
+The default value of `--jobs` option is the number of active CPUs on your
+system.
+
 == `activate` script options
 
 When you source the `activate` script, use the following environment

--- a/vlttng/vlttng_cli.py
+++ b/vlttng/vlttng_cli.py
@@ -33,6 +33,11 @@ import os
 
 
 def _parse_args():
+    try:
+        default_jobs = len(os.sched_getaffinity(0))
+    except:
+        default_jobs = 1
+
     ap = argparse.ArgumentParser()
     ap.add_argument('-f', '--force', action='store_true',
                     help='force the virtual environment creation')
@@ -42,8 +47,8 @@ def _parse_args():
                     action='append',
                     help='ignore project PROJECT (may be repeated)')
     ap.add_argument('-j', '--jobs', nargs='?', const=None, metavar='JOBS',
-                    action='store', type=int,
-                    default=1, help='number of make jobs to run simultaneously')
+                    action='store', type=int, default=default_jobs,
+                    help='number of make jobs to run simultaneously instead of {}'.format(default_jobs))
     ap.add_argument('-l', '--list-default-profiles', action='store_true',
                     help='list default profile names and exit')
     ap.add_argument('-o', '--override', metavar='PROP',


### PR DESCRIPTION
When invoking vlttng, I think it's more helpful to users to use the available system resources by building with a higher level of parallelism by default when more CPUs are available. `vlttng_quick.py` suggests a similar approach to users by prompting with a default based on the available cpu count.

I noticed `vlttng_quick.py` uses `multiprocessing.cpu_count()`, but decided to use `len(os.sched_getaffinity(0))` to avoid importing `multiprocessing` in to the `vlttng.py` script.