### PR TITLE
bt2: Disable man page generation when asciidoc is not available

### DIFF
--- a/vlttng/venv.py
+++ b/vlttng/venv.py
@@ -405,6 +405,8 @@ class VEnvCreator:
             if '--enable-debug-info' in project.configure or '--disable-debug-info' not in project.configure:
                 check_dep('babeltrace2', 'elfutils')
 
+            self._check_man_pages('babeltrace2', projects['babeltrace2'])
+
         if 'lttng-tools' in projects:
             self._check_man_pages('LTTng-tools', projects['lttng-tools'])
 


### PR DESCRIPTION
As done for LTTng-UST and LTTng-tools, disable the generation of man pages when building babeltrace2 if asciidoc is not detected.